### PR TITLE
fix: upgrade react-dom@19.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8885,15 +8885,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.1"
       }
     },
     "node_modules/react-markdown": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "octokit": "^4.1.2",
     "react": "^19.2.1",
     "react-device-detect": "^2.2.3",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.1",
     "react-markdown": "^10.1.0",
     "react-router": "^7.10.0",
     "remark-gfm": "^4.0.1",


### PR DESCRIPTION
This pull request makes a minor update to the `react-dom` dependency in `package.json`, upgrading it from version 19.2.0 to 19.2.1. This is a routine dependency update that may include bug fixes or minor improvements.